### PR TITLE
Enable sonar scan

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the ODPi Egeria project.
+name: Build
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - uses: gradle/wrapper-validation-action@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Gradle packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Build and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew build sonarqube --info

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ plugins {
     id 'dev.jacomet.logging-capabilities' version "0.10.0"
     // This plugin helps resolve jakarta/javax clashes
     id 'de.jjohannes.java-ecosystem-capabilities' version "0.4"
+    id "org.sonarqube" version "3.4.0.2513"
 }
 
 // Only do signing when running under github actinos
@@ -266,4 +267,11 @@ if (System.getenv("CI")) {
     }
 }
 
+sonarqube {
+    properties {
+        property "sonar.projectKey", "odpi_egeria-connector-hivemetastore"
+        property "sonar.organization", "odpi-github"
+        property "sonar.host.url", "https://sonarcloud.io"
+    }
+}
 


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Adds combined build/sonar scan following suggested sonar approach - as this is the first time we've tried this with sonar cloud from GitHub Actions. 

As this is a GitHub action, will need to merge and then check results & iterate

This will run IN ADDITION to the recent additions that follow the pattern in the Postgres repo - once it's clear it's working, can refactor the existing builds - move about the snapshot uploads etc, and may be able to consolidate down to fewer actions