### PR TITLE
Create container image

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Set Release version env variables
         run: |
           echo "VERSION=$(./gradlew properties --no-daemon --console=plain -q | grep '^version:' | awk '{printf $2}')" >> $GITHUB_ENV
-          echo "EGERIA_BASE_IMAGE=quay.io/odpi/egeria:$(./gradlew dependencies | grep org.odpi.egeria:open-connector-framework | awk -F':' '{print $3}' | awk -F' ' '{print $1}' | uniq| head -1)" >> $GITHUB_ENV
+          echo "EGERIA_BASE_IMAGE=\"quay.io/odpi/egeria:$(./gradlew dependencies | grep org.odpi.egeria:open-connector-framework | awk -F':' '{print $3}' | awk -F' ' '{print $1}' | uniq| head -1)\"" >> $GITHUB_ENV
       - name: Build and push to quay.io and docker.io (tag latest only for main!)
         if: ${{ github.ref == 'refs/heads/main'}}
         uses: docker/build-push-action@v3
@@ -71,6 +71,9 @@ jobs:
           push: true
           tags: odpi/egeria:${{ env.VERSION }}, odpi/egeria:latest, quay.io/odpi/egeria-connector-hivemetastore:${{ env.VERSION }}, quay.io/odpi/egeria-connector-hivemetastore:latest
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            EGERIA_BASE_IMAGE=${{ env.EGERIA_BASE_IMAGE }}
+            VERSION=${{ env.VERSION }}
       - name: Build and push( to quay.io and docker.io (no tag latest)
         if: ${{ github.ref != 'refs/heads/main'}}
         uses: docker/build-push-action@v3
@@ -79,6 +82,9 @@ jobs:
           push: true
           tags: odpi/egeria:${{ env.VERSION }}, quay.io/odpi/egeria-connector-hivemetastore:${{ env.VERSION }}
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            EGERIA_BASE_IMAGE=${{ env.EGERIA_BASE_IMAGE }}
+            VERSION=${{ env.VERSION }}
       # --
       - name: Upload Connector
         uses: actions/upload-artifact@v3

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -61,30 +61,33 @@ jobs:
         uses: docker/setup-qemu-action@v2
       - name: Set Release version env variables
         run: |
-          echo "VERSION=$(./gradlew properties --no-daemon --console=plain -q | grep '^version:' | awk '{printf $2}')" >> $GITHUB_ENV
-          echo "EGERIA_BASE_IMAGE=\"quay.io/odpi/egeria:$(./gradlew dependencies | grep org.odpi.egeria:open-connector-framework | awk -F':' '{print $3}' | awk -F' ' '{print $1}' | uniq| head -1)\"" >> $GITHUB_ENV
+          echo "CONNECTOR_VERSION=$(./gradlew properties --no-daemon --console=plain -q | grep '^version:' | awk '{printf $2}')" >> $GITHUB_ENV
+          echo "EGERIA_BASE_IMAGE=quay.io/odpi/egeria" >> $GITHUB_ENV
+          echo "EGERIA_VERSION=$(./gradlew dependencies | grep org.odpi.egeria:open-connector-framework | awk -F':' '{print $3}' | awk -F' ' '{print $1}' | uniq| head -1)" >> $GITHUB_ENV
       - name: Build and push to quay.io and docker.io (tag latest only for main!)
         if: ${{ github.ref == 'refs/heads/main'}}
         uses: docker/build-push-action@v3
         with:
           context: .
           push: true
-          tags: odpi/egeria:${{ env.VERSION }}, odpi/egeria:latest, quay.io/odpi/egeria-connector-hivemetastore:${{ env.VERSION }}, quay.io/odpi/egeria-connector-hivemetastore:latest
+          tags: odpi/egeria:${{ env.CONNECTOR_VERSION }}, odpi/egeria:latest, quay.io/odpi/egeria-connector-hivemetastore:${{ env.CONNECTOR_VERSION }}, quay.io/odpi/egeria-connector-hivemetastore:latest
           platforms: linux/amd64,linux/arm64
           build-args: |
             EGERIA_BASE_IMAGE=${{ env.EGERIA_BASE_IMAGE }}
-            VERSION=${{ env.VERSION }}
+            CONNECTOR_VERSION=${{ env.CONNECTOR_VERSION }}
+            EGERIA_VERSION=${{ env.EGERIA_VERSION }}
       - name: Build and push( to quay.io and docker.io (no tag latest)
         if: ${{ github.ref != 'refs/heads/main'}}
         uses: docker/build-push-action@v3
         with:
           context: .
           push: true
-          tags: odpi/egeria:${{ env.VERSION }}, quay.io/odpi/egeria-connector-hivemetastore:${{ env.VERSION }}
+          tags: odpi/egeria:${{ env.CONNECTOR_VERSION }}, quay.io/odpi/egeria-connector-hivemetastore:${{ env.CONNECTOR_VERSION }}
           platforms: linux/amd64,linux/arm64
           build-args: |
             EGERIA_BASE_IMAGE=${{ env.EGERIA_BASE_IMAGE }}
-            VERSION=${{ env.VERSION }}
+            CONNECTOR_VERSION=${{ env.CONNECTOR_VERSION }}
+            EGERIA_VERSION=${{ env.EGERIA_VERSION }}
       # --
       - name: Upload Connector
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,9 @@ jobs:
           push: true
           tags: odpi/egeria:${{ env.VERSION }}, quay.io/odpi/egeria-connector-hivemetastore:${{ env.VERSION }}
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            EGERIA_BASE_IMAGE=${{ env.EGERIA_BASE_IMAGE }}
+            VERSION=${{ env.VERSION }}
       # Upload the library so that build results can be viewed
       - name: Upload Connector
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,9 @@ jobs:
         uses: docker/setup-qemu-action@v2
       - name: Set Release version env variable
         run: |
-          echo "VERSION=$(./gradlew properties --no-daemon --console=plain -q | grep '^version:' | awk '{printf $2}')" >> $GITHUB_ENV
-          echo "EGERIA_BASE_IMAGE=quay.io/odpi/egeria:$(./gradlew dependencies | grep org.odpi.egeria:open-connector-framework | awk -F':' '{print $3}' | awk -F' ' '{print $1}' | uniq| head -1)" >> $GITHUB_ENV
+          echo "CONNECTOR_VERSION=$(./gradlew properties --no-daemon --console=plain -q | grep '^version:' | awk '{printf $2}')" >> $GITHUB_ENV
+          echo "EGERIA_BASE_IMAGE=quay.io/odpi/egeria" >> $GITHUB_ENV
+          echo "EGERIA_VERSION=$(./gradlew dependencies | grep org.odpi.egeria:open-connector-framework | awk -F':' '{print $3}' | awk -F' ' '{print $1}' | uniq| head -1)" >> $GITHUB_ENV
       - name: Build and push( to quay.io and docker.io (no tag latest)
         uses: docker/build-push-action@v3
         with:
@@ -66,7 +67,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             EGERIA_BASE_IMAGE=${{ env.EGERIA_BASE_IMAGE }}
-            VERSION=${{ env.VERSION }}
+            CONNECTOR_VERSION=${{ env.CONNECTOR_VERSION }}
+            EGERIA_VERSION=${{ env.EGERIA_VERSION }}
       # Upload the library so that build results can be viewed
       - name: Upload Connector
         uses: actions/upload-artifact@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,20 @@
 # Copyright Contributors to the Egeria project
 
 # This is the EGERIA version - typically passed from the ci/cd pipeline
-ARG EGERIA_BASE_IMAGE=quay.io/odpi/egeria:latest
+ARG EGERIA_BASE_IMAGE=quay.io/odpi/egeria
+ARG EGERIA_VERSION=latest
+# Must be set to help get the right files for the connextors
 
-FROM ${EGERIA_BASE_IMAGE}
+FROM ${EGERIA_BASE_IMAGE}:${EGERIA_VERSION}
+ARG CONNECTOR_VERSION=0.1-SNAPSHOT
 
 # Labels from https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys (with additions prefixed    ext)
 # We should inherit all the base labels from the egeria image and only overwrite what is necessary.
-LABEL org.opencontainers.image.description = "Egeria with HMS connector" \
+LABEL org.opencontainers.image.description = "Egeria with Strimzi connector" \
       org.opencontainers.image.documentation = "https://github.com/odpi/egeria-connector-hivemetastore"
 
-# This assumes we only have one uber jar (ensure old versions cleaned out beforehand). Avoids having to pass connector version
-COPY build/libs/egeria-connector-hivemetastore-*-with-dependencies.jar /deployments/server/lib
+ENV CONNECTOR_VERSION ${CONNECTOR_VERSION}
 
+# We need both the hive connector, and the OMRS caching connector
+COPY build/libs/egeria-connector-hivemetastore-${CONNECTOR_VERSION}-jar-with-dependencies.jar /deployments/server/lib
+COPY build/libs/egeria-connector-hivemetastore-${CONNECTOR_VERSION}-jar-with-dependencies.jar /deployments/server/lib

--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,8 @@ dependencies {
     testImplementation "org.odpi.egeria:repository-services-apis:${egeriaversion}"
     compileOnly "org.odpi.egeria:admin-services-api:${egeriaversion}"
     compileOnly "org.odpi.egeria:audit-log-framework:${egeriaversion}"
-    compileOnly "org.odpi.egeria:egeria-connector-omrs-caching:${cachingconnectorversion}"
+    // not yet released, for convenience we will include this for runtime
+    implementation "org.odpi.egeria:egeria-connector-omrs-caching:${cachingconnectorversion}"
 
     implementation 'org.apache.thrift:libthrift:0.13.0'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,16 +5,16 @@
 org.gradle.parallel=true
 
 # Caching
-org.gradle.caching=false
+org.gradle.caching=true
 
-# Watch fileystem - disable - too many files swamps OS
-org.gradle.vfs.watch=false
+# Watch filesystem for changes. Disable if memory constrained
+org.gradle.vfs.watch=true
 
 # Default logging output
 org.gradle.console=auto
 
-# Stop if we get a warning
-org.gradle.warning.mode=summary
+# Stop if we get a warning - prevents us using deprecated features
+org.gradle.warning.mode=fail
 
 # Defer configuration until needed
 org.gradle.configureondemand=true


### PR DESCRIPTION
* Adds container image published to quay.io & docker.io
* egeria base image version is based on the 'open-connector-framework' dependency so that we match with appropriate runtime
* Included omrs caching connector at runtime (ie compileOnly->Implementation) as this simplifies creation of a usable container (we can switch this back if/when we have omrs caching connector fully setup with released artifacts)