### PR TITLE
Correct incorrect image tag

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: odpi/egeria:${{ env.CONNECTOR_VERSION }}, odpi/egeria:latest, quay.io/odpi/egeria-connector-hivemetastore:${{ env.CONNECTOR_VERSION }}, quay.io/odpi/egeria-connector-hivemetastore:latest
+          tags: odpi/egeria-connector-hivemetastore:${{ env.CONNECTOR_VERSION }}, odpi/egeria:latest, quay.io/odpi/egeria-connector-hivemetastore:${{ env.CONNECTOR_VERSION }}, quay.io/odpi/egeria-connector-hivemetastore:latest
           platforms: linux/amd64,linux/arm64
           build-args: |
             EGERIA_BASE_IMAGE=${{ env.EGERIA_BASE_IMAGE }}
@@ -82,7 +82,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: odpi/egeria:${{ env.CONNECTOR_VERSION }}, quay.io/odpi/egeria-connector-hivemetastore:${{ env.CONNECTOR_VERSION }}
+          tags: odpi/egeria-connector-hive-metastore:${{ env.CONNECTOR_VERSION }}, quay.io/odpi/egeria-connector-hivemetastore:${{ env.CONNECTOR_VERSION }}
           platforms: linux/amd64,linux/arm64
           build-args: |
             EGERIA_BASE_IMAGE=${{ env.EGERIA_BASE_IMAGE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: odpi/egeria:${{ env.VERSION }}, quay.io/odpi/egeria-connector-hivemetastore:${{ env.VERSION }}
+          tags: odpi/egeria-connector-hivemetastore:${{ env.VERSION }}, quay.io/odpi/egeria-connector-hivemetastore:${{ env.VERSION }}
           platforms: linux/amd64,linux/arm64
           build-args: |
             EGERIA_BASE_IMAGE=${{ env.EGERIA_BASE_IMAGE }}


### PR DESCRIPTION
This is an urgent fix to correct the 'tag' used to publish container images

The incorrect label could result in updating the main egeria image with an incorrect version 

